### PR TITLE
Add beam search algorithm based on PathfindingProcess

### DIFF
--- a/src/Pathfinding.App.Console/Extensions/AlgorithmExtensions.cs
+++ b/src/Pathfinding.App.Console/Extensions/AlgorithmExtensions.cs
@@ -25,6 +25,7 @@ internal static class AlgorithmExtensions
             Algorithms.BidirectRandom => Resource.BidirectRandom,
             Algorithms.DepthFirstRandom => Resource.DepthRandom,
             Algorithms.IdaStar => "IDA*",
+            Algorithms.BeamSearch => Resource.BeamSearch,
             _ => string.Empty
         };
     }

--- a/src/Pathfinding.App.Console/Factories/Algos/BeamSearchAlgorithmFactory.cs
+++ b/src/Pathfinding.App.Console/Factories/Algos/BeamSearchAlgorithmFactory.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models;
+
+namespace Pathfinding.App.Console.Factories.Algos;
+
+public sealed class BeamSearchAlgorithmFactory(IHeuristicsFactory heuristicsFactory)
+    : IAlgorithmFactory<BeamSearchAlgorithm>
+{
+    public BeamSearchAlgorithm CreateAlgorithm(
+        IReadOnlyCollection<IPathfindingVertex> range,
+        IAlgorithmBuildInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(info.Heuristics, nameof(info.Heuristics));
+
+        var weight = info.Weight ?? 1;
+        var heuristic = heuristicsFactory.CreateHeuristic(info.Heuristics.Value, weight);
+        return new(range, heuristic);
+    }
+}

--- a/src/Pathfinding.App.Console/Injection/Modules.cs
+++ b/src/Pathfinding.App.Console/Injection/Modules.cs
@@ -138,6 +138,8 @@ internal static class Modules
             .WithMetadata(MetadataKeys.Order, 12).SingleInstance().As<IAlgorithmFactory<PathfindingProcess>>();
         builder.RegisterType<DistanceFirstAlgorithmFactory>().WithMetadata(MetadataKeys.Algorithm, Algorithms.DistanceFirst)
             .WithMetadata(MetadataKeys.Order, 11).SingleInstance().As<IAlgorithmFactory<PathfindingProcess>>();
+        builder.RegisterType<BeamSearchAlgorithmFactory>().WithMetadata(MetadataKeys.Algorithm, Algorithms.BeamSearch)
+            .WithMetadata(MetadataKeys.Order, 17).SingleInstance().As<IAlgorithmFactory<PathfindingProcess>>();
         builder.RegisterType<AStarGreedyAlgorithmFactory>().WithMetadata(MetadataKeys.Algorithm, Algorithms.AStarGreedy)
             .WithMetadata(MetadataKeys.Order, 7).SingleInstance().As<IAlgorithmFactory<PathfindingProcess>>();
         builder.RegisterType<AStarLeeAlgorithmFactory>().WithMetadata(MetadataKeys.Algorithm, Algorithms.AStarLee)

--- a/src/Pathfinding.App.Console/Resources/Resource.Designer.cs
+++ b/src/Pathfinding.App.Console/Resources/Resource.Designer.cs
@@ -97,6 +97,15 @@ namespace Pathfinding.App.Console.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Beam search.
+        /// </summary>
+        internal static string BeamSearch {
+            get {
+                return ResourceManager.GetString("BeamSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bidirect A*.
         /// </summary>
         internal static string BidirectAStar {

--- a/src/Pathfinding.App.Console/Resources/Resource.resx
+++ b/src/Pathfinding.App.Console/Resources/Resource.resx
@@ -129,6 +129,9 @@
   <data name="AStarLee" xml:space="preserve">
     <value>A* Lee</value>
   </data>
+  <data name="BeamSearch" xml:space="preserve">
+    <value>Beam search</value>
+  </data>
   <data name="BidirectAStar" xml:space="preserve">
     <value>Bidirect A*</value>
   </data>

--- a/src/Pathfinding.App.Console/Views/RunsListView.cs
+++ b/src/Pathfinding.App.Console/Views/RunsListView.cs
@@ -54,6 +54,7 @@ internal sealed partial class RunsListView : FrameView
                         break;
                     case Algorithms.DistanceFirst:
                     case Algorithms.AStarLee:
+                    case Algorithms.BeamSearch:
                         messenger.Send(new CloseStepRulesViewMessage());
                         messenger.Send(new CloseRunPopulateViewMessage());
                         messenger.Send(new OpenHeuristicsViewMessage());

--- a/src/Pathfinding.Domain.Core/Enums/Algorithms.cs
+++ b/src/Pathfinding.Domain.Core/Enums/Algorithms.cs
@@ -19,5 +19,6 @@ public enum Algorithms
     Random = 12,
     BidirectRandom = 13,
     DepthFirstRandom = 14,
-    IdaStar = 15
+    IdaStar = 15,
+    BeamSearch = 16
 }

--- a/src/Pathfinding.Infrastructure.Business/Algorithms/BeamSearchAlgorithm.cs
+++ b/src/Pathfinding.Infrastructure.Business/Algorithms/BeamSearchAlgorithm.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Pathfinding.Infrastructure.Business.Algorithms.Exceptions;
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Algorithms;
+
+public sealed class BeamSearchAlgorithm(
+    IReadOnlyCollection<IPathfindingVertex> pathfindingRange,
+    IHeuristic heuristic,
+    int beamWidth = DefaultBeamWidth)
+    : WaveAlgorithm<List<BeamSearchAlgorithm.BeamEntry>>(pathfindingRange)
+{
+    private const int DefaultBeamWidth = 10;
+
+    private readonly IHeuristic heuristicFunction = heuristic ?? throw new ArgumentNullException(nameof(heuristic));
+    private readonly int beamWidthLimit = beamWidth > 0
+        ? beamWidth
+        : throw new ArgumentOutOfRangeException(nameof(beamWidth));
+
+    private readonly Dictionary<Coordinate, double> frontierPriorities = [];
+
+    public BeamSearchAlgorithm(IReadOnlyCollection<IPathfindingVertex> pathfindingRange)
+        : this(pathfindingRange, new ManhattanDistance())
+    {
+    }
+
+    protected override void PrepareForSubPathfinding(SubRange range)
+    {
+        base.PrepareForSubPathfinding(range);
+        Storage.Clear();
+        frontierPriorities.Clear();
+    }
+
+    protected override void DropState()
+    {
+        base.DropState();
+        Storage.Clear();
+        frontierPriorities.Clear();
+    }
+
+    protected override void MoveNextVertex()
+    {
+        if (Storage.Count == 0)
+        {
+            throw new DeadendVertexException();
+        }
+
+        var next = Storage[0];
+        Storage.RemoveAt(0);
+        frontierPriorities.Remove(next.Vertex.Position);
+        CurrentVertex = next.Vertex;
+    }
+
+    protected override void RelaxVertex(IPathfindingVertex vertex)
+    {
+        if (Visited.Contains(vertex))
+        {
+            return;
+        }
+
+        var priority = CalculatePriority(vertex);
+        if (frontierPriorities.TryGetValue(vertex.Position, out var current)
+            && current <= priority)
+        {
+            return;
+        }
+
+        if (frontierPriorities.ContainsKey(vertex.Position))
+        {
+            RemoveVertex(vertex);
+        }
+
+        Storage.Add(new(vertex, priority));
+        frontierPriorities[vertex.Position] = priority;
+        Storage.Sort(CompareEntries);
+        TrimBeam();
+        Traces[vertex.Position] = CurrentVertex;
+    }
+
+    private double CalculatePriority(IPathfindingVertex vertex)
+    {
+        return heuristicFunction.Calculate(vertex, CurrentRange.Target);
+    }
+
+    private void TrimBeam()
+    {
+        while (Storage.Count > beamWidthLimit)
+        {
+            var removed = Storage[^1];
+            frontierPriorities.Remove(removed.Vertex.Position);
+            Traces.Remove(removed.Vertex.Position);
+            Storage.RemoveAt(Storage.Count - 1);
+        }
+    }
+
+    private void RemoveVertex(IPathfindingVertex vertex)
+    {
+        for (int i = 0; i < Storage.Count; i++)
+        {
+            if (Storage[i].Vertex.Equals(vertex))
+            {
+                Storage.RemoveAt(i);
+                break;
+            }
+        }
+    }
+
+    private static int CompareEntries(BeamEntry left, BeamEntry right)
+    {
+        return left.Priority.CompareTo(right.Priority);
+    }
+
+    private readonly record struct BeamEntry(IPathfindingVertex Vertex, double Priority);
+}


### PR DESCRIPTION
## Summary
- implement a beam search algorithm that reuses the PathfindingProcess workflow while bounding the open set
- wire the new algorithm into the console app via a factory, dependency injection registration, and enum/resource updates

## Testing
- dotnet build *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6905242656188333901a1f863942dcba