### PR TITLE
Adjust beam search to use percentage-based width

### DIFF
--- a/src/Pathfinding.App.Console/Factories/Algos/BeamSearchAlgorithmFactory.cs
+++ b/src/Pathfinding.App.Console/Factories/Algos/BeamSearchAlgorithmFactory.cs
@@ -15,8 +15,8 @@ public sealed class BeamSearchAlgorithmFactory(IHeuristicsFactory heuristicsFact
     {
         ArgumentNullException.ThrowIfNull(info.Heuristics, nameof(info.Heuristics));
 
-        var weight = info.Weight ?? 1;
-        var heuristic = heuristicsFactory.CreateHeuristic(info.Heuristics.Value, weight);
-        return new(range, heuristic);
+        var heuristic = heuristicsFactory.CreateHeuristic(info.Heuristics.Value, 1);
+        var beamWidthPercentage = info.Weight ?? BeamSearchAlgorithm.DefaultBeamWidthPercentage;
+        return new(range, heuristic, beamWidthPercentage);
     }
 }


### PR DESCRIPTION
## Summary
- update the beam search implementation to clamp its frontier by a percentage-based limit instead of a fixed entry count
- allow the console factory to pass the requested width percentage (defaulting to the algorithm default) when constructing the beam search

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_69062fdbe530833384216f75207e35d6