### PR TITLE
Add Canberra and Hamming heuristics with new neighborhood layers

### DIFF
--- a/src/Pathfinding.App.Console/Extensions/HeuristicsExtensions.cs
+++ b/src/Pathfinding.App.Console/Extensions/HeuristicsExtensions.cs
@@ -13,6 +13,8 @@ internal static class HeuristicsExtensions
             Heuristics.Chebyshev => Resource.Chebyshev,
             Heuristics.Diagonal => Resource.Diagonal,
             Heuristics.Manhattan => Resource.Manhattan,
+            Heuristics.Canberra => Resource.Canberra,
+            Heuristics.Hamming => Resource.Hamming,
             _ => string.Empty
         };
     }

--- a/src/Pathfinding.App.Console/Extensions/NeighborhoodsExtensions.cs
+++ b/src/Pathfinding.App.Console/Extensions/NeighborhoodsExtensions.cs
@@ -13,6 +13,8 @@ internal static class NeighborhoodsExtensions
             Neighborhoods.VonNeumann => Resource.VonNeumann,
             Neighborhoods.Diagonal => Resource.DiagonalNeighborhood,
             Neighborhoods.Knight => Resource.Knight,
+            Neighborhoods.Hexagonal => Resource.Hexagonal,
+            Neighborhoods.ExtendedMoore => Resource.ExtendedMoore,
             _ => string.Empty
         };
     }

--- a/src/Pathfinding.App.Console/Injection/Modules.cs
+++ b/src/Pathfinding.App.Console/Injection/Modules.cs
@@ -93,6 +93,10 @@ internal static class Modules
             .WithMetadata(MetadataKeys.Heuristics, Heuristics.Chebyshev);
         builder.RegisterType<ManhattanDistance>().As<IHeuristic>().SingleInstance()
             .WithMetadata(MetadataKeys.Heuristics, Heuristics.Manhattan);
+        builder.RegisterType<CanberraDistance>().As<IHeuristic>().SingleInstance()
+            .WithMetadata(MetadataKeys.Heuristics, Heuristics.Canberra);
+        builder.RegisterType<HammingDistance>().As<IHeuristic>().SingleInstance()
+            .WithMetadata(MetadataKeys.Heuristics, Heuristics.Hamming);
         builder.RegisterType<HeuristicsFactory>().As<IHeuristicsFactory>().SingleInstance();
 
         builder.RegisterType<MooreNeighborhoodLayer>().Keyed<NeighborhoodLayer>(KeyFilters.Neighborhoods)
@@ -103,6 +107,10 @@ internal static class Modules
             .SingleInstance().WithMetadata(MetadataKeys.Neighborhoods, Neighborhoods.Diagonal);
         builder.RegisterType<KnightsNeighborhoodLayer>().Keyed<NeighborhoodLayer>(KeyFilters.Neighborhoods)
             .SingleInstance().WithMetadata(MetadataKeys.Neighborhoods, Neighborhoods.Knight);
+        builder.RegisterType<HexagonalNeighborhoodLayer>().Keyed<NeighborhoodLayer>(KeyFilters.Neighborhoods)
+            .SingleInstance().WithMetadata(MetadataKeys.Neighborhoods, Neighborhoods.Hexagonal);
+        builder.RegisterType<ExtendedMooreNeighborhoodLayer>().Keyed<NeighborhoodLayer>(KeyFilters.Neighborhoods)
+            .SingleInstance().WithMetadata(MetadataKeys.Neighborhoods, Neighborhoods.ExtendedMoore);
         builder.RegisterType<NeighborhoodLayerFactory>().As<INeighborhoodLayerFactory>()
             .WithAttributeFiltering().SingleInstance();
 

--- a/src/Pathfinding.App.Console/Resources/Resource.Designer.cs
+++ b/src/Pathfinding.App.Console/Resources/Resource.Designer.cs
@@ -185,7 +185,16 @@ namespace Pathfinding.App.Console.Resources {
                 return ResourceManager.GetString("Cosine", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Canberra.
+        /// </summary>
+        internal static string Canberra {
+            get {
+                return ResourceManager.GetString("Canberra", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to DFS cost.
         /// </summary>
@@ -311,7 +320,16 @@ namespace Pathfinding.App.Console.Resources {
                 return ResourceManager.GetString("Failure", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hamming.
+        /// </summary>
+        internal static string Hamming {
+            get {
+                return ResourceManager.GetString("Hamming", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Graph field.
         /// </summary>
@@ -338,7 +356,16 @@ namespace Pathfinding.App.Console.Resources {
                 return ResourceManager.GetString("High", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hexagonal.
+        /// </summary>
+        internal static string Hexagonal {
+            get {
+                return ResourceManager.GetString("Hexagonal", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Import.
         /// </summary>
@@ -428,7 +455,16 @@ namespace Pathfinding.App.Console.Resources {
                 return ResourceManager.GetString("Moore", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Extended Moore.
+        /// </summary>
+        internal static string ExtendedMoore {
+            get {
+                return ResourceManager.GetString("ExtendedMoore", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to No.
         /// </summary>

--- a/src/Pathfinding.App.Console/Resources/Resource.resx
+++ b/src/Pathfinding.App.Console/Resources/Resource.resx
@@ -159,6 +159,9 @@
   <data name="Cosine" xml:space="preserve">
     <value>Cosine</value>
   </data>
+  <data name="Canberra" xml:space="preserve">
+    <value>Canberra</value>
+  </data>
   <data name="CostGreedy" xml:space="preserve">
     <value>DFS cost</value>
   </data>
@@ -201,6 +204,9 @@
   <data name="Failure" xml:space="preserve">
     <value>Failure</value>
   </data>
+  <data name="Hamming" xml:space="preserve">
+    <value>Hamming</value>
+  </data>
   <data name="GraphField" xml:space="preserve">
     <value>Graph field</value>
   </data>
@@ -209,6 +215,9 @@
   </data>
   <data name="High" xml:space="preserve">
     <value>High</value>
+  </data>
+  <data name="Hexagonal" xml:space="preserve">
+    <value>Hexagonal</value>
   </data>
   <data name="Import" xml:space="preserve">
     <value>Import</value>
@@ -239,6 +248,9 @@
   </data>
   <data name="Moore" xml:space="preserve">
     <value>Moore</value>
+  </data>
+  <data name="ExtendedMoore" xml:space="preserve">
+    <value>Extended Moore</value>
   </data>
   <data name="No" xml:space="preserve">
     <value>No</value>

--- a/src/Pathfinding.Domain.Core/Enums/Heuristics.cs
+++ b/src/Pathfinding.Domain.Core/Enums/Heuristics.cs
@@ -7,5 +7,7 @@ public enum Heuristics
     Euclidean,
     Chebyshev,
     Diagonal,
-    Manhattan
+    Manhattan,
+    Canberra,
+    Hamming
 }

--- a/src/Pathfinding.Domain.Core/Enums/Neighborhoods.cs
+++ b/src/Pathfinding.Domain.Core/Enums/Neighborhoods.cs
@@ -7,5 +7,7 @@ public enum Neighborhoods
     Moore,
     VonNeumann,
     Diagonal,
-    Knight
+    Knight,
+    Hexagonal,
+    ExtendedMoore
 }

--- a/src/Pathfinding.Infrastructure.Business/Algorithms/Heuristics/CanberraDistance.cs
+++ b/src/Pathfinding.Infrastructure.Business/Algorithms/Heuristics/CanberraDistance.cs
@@ -1,0 +1,24 @@
+﻿using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Extensions;
+using System.Runtime.CompilerServices;
+
+namespace Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+
+public sealed class CanberraDistance : Distance
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override double Calculate(IPathfindingVertex first, IPathfindingVertex second)
+    {
+        return first.Position
+            .Zip(second.Position, Zip)
+            .AggregateOrDefault(Aggregate);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected override double Zip(int first, int second)
+    {
+        var numerator = Math.Abs(first - second);
+        var denominator = Math.Abs(first) + Math.Abs(second);
+        return denominator == 0 ? 0 : numerator / denominator;
+    }
+}

--- a/src/Pathfinding.Infrastructure.Business/Algorithms/Heuristics/HammingDistance.cs
+++ b/src/Pathfinding.Infrastructure.Business/Algorithms/Heuristics/HammingDistance.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+
+public sealed class HammingDistance : Distance
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected override double Zip(int first, int second)
+    {
+        return first == second ? 0 : 1;
+    }
+}

--- a/src/Pathfinding.Infrastructure.Business/Layers/ExtendedMooreNeighborhoodLayer.cs
+++ b/src/Pathfinding.Infrastructure.Business/Layers/ExtendedMooreNeighborhoodLayer.cs
@@ -1,0 +1,13 @@
+﻿using Pathfinding.Infrastructure.Data.Pathfinding.Neighborhoods;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Layers;
+
+public sealed class ExtendedMooreNeighborhoodLayer : NeighborhoodLayer
+{
+    protected override INeighborhood CreateNeighborhood(Coordinate coordinate)
+    {
+        return new ExtendedMooreNeighborhood(coordinate);
+    }
+}

--- a/src/Pathfinding.Infrastructure.Business/Layers/HexagonalNeighborhoodLayer.cs
+++ b/src/Pathfinding.Infrastructure.Business/Layers/HexagonalNeighborhoodLayer.cs
@@ -1,0 +1,13 @@
+﻿using Pathfinding.Infrastructure.Data.Pathfinding.Neighborhoods;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Layers;
+
+public sealed class HexagonalNeighborhoodLayer : NeighborhoodLayer
+{
+    protected override INeighborhood CreateNeighborhood(Coordinate coordinate)
+    {
+        return new HexagonalNeighborhood(coordinate);
+    }
+}

--- a/src/Pathfinding.Infrastructure.Data/Pathfinding/Neighborhoods/ExtendedMooreNeighborhood.cs
+++ b/src/Pathfinding.Infrastructure.Data/Pathfinding/Neighborhoods/ExtendedMooreNeighborhood.cs
@@ -1,0 +1,56 @@
+﻿using Pathfinding.Shared.Primitives;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Pathfinding.Infrastructure.Data.Pathfinding.Neighborhoods;
+
+[DebuggerDisplay("Count = {Count}")]
+public sealed class ExtendedMooreNeighborhood(Coordinate coordinate) : Neighborhood(coordinate)
+{
+    private IReadOnlyCollection<Coordinate>? neighbors;
+
+    protected override IReadOnlyCollection<Coordinate> Filter(Coordinate coordinate)
+    {
+        return neighbors ??= CreateNeighbors();
+    }
+
+    private IReadOnlyCollection<Coordinate> CreateNeighbors()
+    {
+        var dimension = SelfCoordinate.Count;
+        var deltas = new int[dimension];
+        var coordinates = new HashSet<Coordinate>();
+
+        void Collect(int depth)
+        {
+            if (depth == dimension)
+            {
+                if (deltas.All(offset => offset == 0))
+                {
+                    return;
+                }
+
+                if (deltas.Select(Math.Abs).Max() <= 2)
+                {
+                    var values = new int[dimension];
+                    for (int i = 0; i < dimension; i++)
+                    {
+                        values[i] = SelfCoordinate[i] + deltas[i];
+                    }
+
+                    coordinates.Add(new(values));
+                }
+
+                return;
+            }
+
+            for (int offset = -2; offset <= 2; offset++)
+            {
+                deltas[depth] = offset;
+                Collect(depth + 1);
+            }
+        }
+
+        Collect(0);
+        return coordinates;
+    }
+}

--- a/src/Pathfinding.Infrastructure.Data/Pathfinding/Neighborhoods/HexagonalNeighborhood.cs
+++ b/src/Pathfinding.Infrastructure.Data/Pathfinding/Neighborhoods/HexagonalNeighborhood.cs
@@ -1,0 +1,46 @@
+﻿using Pathfinding.Shared.Primitives;
+using System.Diagnostics;
+
+namespace Pathfinding.Infrastructure.Data.Pathfinding.Neighborhoods;
+
+[DebuggerDisplay("Count = {Count}")]
+public sealed class HexagonalNeighborhood(Coordinate coordinate) : Neighborhood(coordinate)
+{
+    private IReadOnlyCollection<Coordinate>? neighbors;
+
+    protected override IReadOnlyCollection<Coordinate> Filter(Coordinate coordinate)
+    {
+        return neighbors ??= CreateNeighbors();
+    }
+
+    private IReadOnlyCollection<Coordinate> CreateNeighbors()
+    {
+        if (SelfCoordinate.Count < 2)
+        {
+            return Array.Empty<Coordinate>();
+        }
+
+        var dimensions = SelfCoordinate.Count;
+        var result = new Coordinate[6];
+        result[0] = Offset(1, 0, dimensions);
+        result[1] = Offset(-1, 0, dimensions);
+        result[2] = Offset(0, 1, dimensions);
+        result[3] = Offset(0, -1, dimensions);
+        result[4] = Offset(1, -1, dimensions);
+        result[5] = Offset(-1, 1, dimensions);
+        return result;
+    }
+
+    private Coordinate Offset(int dx, int dy, int dimensions)
+    {
+        var values = new int[dimensions];
+        for (int i = 0; i < dimensions; i++)
+        {
+            values[i] = SelfCoordinate[i];
+        }
+
+        values[0] += dx;
+        values[1] += dy;
+        return new(values);
+    }
+}


### PR DESCRIPTION
## Summary
- add Canberra and Hamming heuristic implementations and expose them through the console factory
- introduce hexagonal and extended Moore neighborhood implementations and register their layers
- update enums and console resources so the new options appear throughout the UI

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690cd00e0b0083339a6a728aca771f7f