### PR TITLE
Add unit tests for remaining console view models

### DIFF
--- a/tests/Pathfinding.App.Console.Tests/TestPathfindingProcess.cs
+++ b/tests/Pathfinding.App.Console.Tests/TestPathfindingProcess.cs
@@ -1,0 +1,64 @@
+using Pathfinding.App.Console.Factories;
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.App.Console.Tests;
+
+internal sealed class TestAlgorithmFactory : IAlgorithmFactory<PathfindingProcess>
+{
+    public PathfindingProcess CreateAlgorithm(
+        IReadOnlyCollection<IPathfindingVertex> range,
+        IAlgorithmBuildInfo info)
+    {
+        return new TestPathfindingProcess(range);
+    }
+}
+
+internal sealed class TestPathfindingProcess : PathfindingProcess
+{
+    private SubRange currentRange;
+    private bool isDestination;
+
+    public TestPathfindingProcess(IReadOnlyCollection<IPathfindingVertex> range)
+        : base(range)
+    {
+    }
+
+    protected override void PrepareForSubPathfinding(SubRange range)
+    {
+        currentRange = range;
+        isDestination = false;
+    }
+
+    protected override bool IsDestination() => isDestination;
+
+    protected override void MoveNextVertex()
+    {
+        isDestination = true;
+    }
+
+    protected override void InspectCurrentVertex()
+    {
+    }
+
+    protected override void VisitCurrentVertex()
+    {
+        if (currentRange.Source != NullPathfindingVertex.Interface)
+        {
+            var neighbors = currentRange.Target == NullPathfindingVertex.Interface
+                ? Array.Empty<IPathfindingVertex>()
+                : new[] { currentRange.Target };
+            RaiseVertexProcessed(currentRange.Source, neighbors);
+        }
+    }
+
+    protected override IGraphPath GetSubPath() => NullGraphPath.Interface;
+
+    protected override void DropState()
+    {
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphImportViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphImportViewModelTests.cs
@@ -10,6 +10,7 @@ using Pathfinding.Service.Interface.Models.Read;
 using Pathfinding.Service.Interface.Models.Serialization;
 using System.Collections.Generic;
 using System.IO;
+using System.Reactive.Linq;
 using Serializer = Pathfinding.Service.Interface.ISerializer<Pathfinding.Service.Interface.Models.Serialization.PathfindingHistoriesSerializationModel>;
 
 namespace Pathfinding.App.Console.Tests.ViewModelTests;
@@ -27,22 +28,20 @@ internal sealed class GraphImportViewModelTests
 
         var serializationModel = new PathfindingHistoriesSerializationModel
         {
-            Histories = new[]
-            {
+            Histories =
+            [
                 new PathfindingHistorySerializationModel
                 {
-                    Graph = new GraphModel<GraphVertexModel>
+                    Graph = new GraphSerializationModel
                     {
-                        Id = 5,
                         Name = "Imported",
                         Neighborhood = Neighborhoods.Moore,
-                        Status = GraphStatuses.Active,
+                        Status = GraphStatuses.Editable,
                         SmoothLevel = SmoothLevels.No,
-                        Vertices = [],
                         DimensionSizes = []
                     }
                 }
-            }
+            ]
         };
 
         var created = new[]
@@ -54,7 +53,7 @@ internal sealed class GraphImportViewModelTests
                     Id = 5,
                     Name = "Imported",
                     Neighborhood = Neighborhoods.Moore,
-                    Status = GraphStatuses.Active,
+                    Status = GraphStatuses.Editable,
                     SmoothLevel = SmoothLevels.No,
                     Vertices = [],
                     DimensionSizes = []
@@ -85,7 +84,7 @@ internal sealed class GraphImportViewModelTests
                 })
         };
 
-        using var viewModel = new GraphImportViewModel(
+        var viewModel = new GraphImportViewModel(
             serviceMock.Object,
             messenger,
             serializerMeta,
@@ -95,7 +94,7 @@ internal sealed class GraphImportViewModelTests
         messenger.Register<GraphsCreatedMessage>(this, (_, msg) => createdMessage = msg);
 
         await viewModel.ImportGraphCommand.Execute(() =>
-            new StreamModel(new MemoryStream(new byte[] { 1, 2, 3 }), StreamFormat.Json));
+            new StreamModel(new MemoryStream([1, 2, 3]), StreamFormat.Json));
 
         Assert.Multiple(() =>
         {
@@ -128,7 +127,7 @@ internal sealed class GraphImportViewModelTests
                 })
         };
 
-        using var viewModel = new GraphImportViewModel(
+        var viewModel = new GraphImportViewModel(
             serviceMock.Object,
             messenger,
             serializerMeta,

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphImportViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphImportViewModelTests.cs
@@ -1,0 +1,143 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Logging.Interface;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models.Read;
+using Pathfinding.Service.Interface.Models.Serialization;
+using System.Collections.Generic;
+using System.IO;
+using Serializer = Pathfinding.Service.Interface.ISerializer<Pathfinding.Service.Interface.Models.Serialization.PathfindingHistoriesSerializationModel>;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class GraphImportViewModelTests
+{
+    [Test]
+    public async Task ImportGraphCommand_ShouldDeserializeAndPublishMessageAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var serviceMock = new Mock<IGraphRequestService<GraphVertexModel>>();
+        var serializerMock = new Mock<Serializer>();
+        var logMock = new Mock<ILog>();
+
+        var serializationModel = new PathfindingHistoriesSerializationModel
+        {
+            Histories = new[]
+            {
+                new PathfindingHistorySerializationModel
+                {
+                    Graph = new GraphModel<GraphVertexModel>
+                    {
+                        Id = 5,
+                        Name = "Imported",
+                        Neighborhood = Neighborhoods.Moore,
+                        Status = GraphStatuses.Active,
+                        SmoothLevel = SmoothLevels.No,
+                        Vertices = [],
+                        DimensionSizes = []
+                    }
+                }
+            }
+        };
+
+        var created = new[]
+        {
+            new PathfindingHistoryModel<GraphVertexModel>
+            {
+                Graph = new GraphModel<GraphVertexModel>
+                {
+                    Id = 5,
+                    Name = "Imported",
+                    Neighborhood = Neighborhoods.Moore,
+                    Status = GraphStatuses.Active,
+                    SmoothLevel = SmoothLevels.No,
+                    Vertices = [],
+                    DimensionSizes = []
+                }
+            }
+        };
+
+        serializerMock
+            .Setup(x => x.DeserializeFromAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(serializationModel);
+
+        serviceMock
+            .Setup(x => x.CreatePathfindingHistoriesAsync(
+                It.IsAny<IEnumerable<PathfindingHistorySerializationModel>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(created);
+
+        var serializerMeta = new[]
+        {
+            new Autofac.Features.Metadata.Meta<Serializer>(
+                serializerMock.Object,
+                new Dictionary<string, object>
+                {
+                    [Pathfinding.App.Console.Injection.MetadataKeys.Order] = 1,
+                    [Pathfinding.App.Console.Injection.MetadataKeys.ExportFormat] = StreamFormat.Json
+                })
+        };
+
+        using var viewModel = new GraphImportViewModel(
+            serviceMock.Object,
+            messenger,
+            serializerMeta,
+            logMock.Object);
+
+        GraphsCreatedMessage createdMessage = null;
+        messenger.Register<GraphsCreatedMessage>(this, (_, msg) => createdMessage = msg);
+
+        await viewModel.ImportGraphCommand.Execute(() =>
+            new StreamModel(new MemoryStream(new byte[] { 1, 2, 3 }), StreamFormat.Json));
+
+        Assert.Multiple(() =>
+        {
+            serializerMock.Verify(x => x.DeserializeFromAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+            serviceMock.Verify(x => x.CreatePathfindingHistoriesAsync(
+                It.IsAny<IEnumerable<PathfindingHistorySerializationModel>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+            Assert.That(createdMessage, Is.Not.Null);
+            logMock.Verify(x => x.Info(It.IsAny<string>()), Times.Once);
+        });
+    }
+
+    [Test]
+    public async Task ImportGraphCommand_EmptyStream_ShouldNotCallServiceAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var serviceMock = new Mock<IGraphRequestService<GraphVertexModel>>();
+        var serializerMock = new Mock<Serializer>();
+
+        var serializerMeta = new[]
+        {
+            new Autofac.Features.Metadata.Meta<Serializer>(
+                serializerMock.Object,
+                new Dictionary<string, object>
+                {
+                    [Pathfinding.App.Console.Injection.MetadataKeys.Order] = 1,
+                    [Pathfinding.App.Console.Injection.MetadataKeys.ExportFormat] = StreamFormat.Json
+                })
+        };
+
+        using var viewModel = new GraphImportViewModel(
+            serviceMock.Object,
+            messenger,
+            serializerMeta,
+            Mock.Of<ILog>());
+
+        await viewModel.ImportGraphCommand.Execute(() => StreamModel.Empty);
+
+        serviceMock.Verify(x => x.CreatePathfindingHistoriesAsync(
+            It.IsAny<IEnumerable<PathfindingHistorySerializationModel>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
@@ -9,6 +9,7 @@ using Pathfinding.Domain.Core.Enums;
 using Pathfinding.Logging.Interface;
 using Pathfinding.Service.Interface;
 using Pathfinding.Service.Interface.Models.Read;
+using System.Reactive.Linq;
 
 namespace Pathfinding.App.Console.Tests.ViewModelTests;
 
@@ -22,7 +23,7 @@ internal sealed class GraphUpdateViewModelTests
         var serviceMock = new Mock<IGraphInfoRequestService>();
         var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
         neighborhoodFactoryMock.SetupGet(x => x.Allowed)
-            .Returns(new[] { Neighborhoods.Moore, Neighborhoods.Diagonal });
+            .Returns([Neighborhoods.Moore, Neighborhoods.Diagonal]);
 
         using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
 
@@ -44,7 +45,7 @@ internal sealed class GraphUpdateViewModelTests
         var messenger = new StrongReferenceMessenger();
         var serviceMock = new Mock<IGraphInfoRequestService>();
         var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
-        neighborhoodFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Neighborhoods>());
+        neighborhoodFactoryMock.SetupGet(x => x.Allowed).Returns([]);
 
         using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
 
@@ -68,7 +69,7 @@ internal sealed class GraphUpdateViewModelTests
         var serviceMock = new Mock<IGraphInfoRequestService>();
         var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
         neighborhoodFactoryMock.SetupGet(x => x.Allowed)
-            .Returns(new[] { Neighborhoods.Moore });
+            .Returns([Neighborhoods.Moore]);
 
         var graphInfoModel = Generators.GenerateGraphInfos(1).Single();
         var newName = graphInfoModel.Name + "_updated";
@@ -91,7 +92,7 @@ internal sealed class GraphUpdateViewModelTests
             .Setup(x => x.UpdateGraphInfoAsync(
                 It.IsAny<GraphInformationModel>(),
                 It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(Task.FromResult(true));
 
         var graphTableMessages = new List<AwaitGraphUpdatedMessage>();
         messenger.Register<AwaitGraphUpdatedMessage, int>(this, Tokens.GraphTable, (_, msg) =>

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
@@ -1,0 +1,150 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Factories;
+using Pathfinding.App.Console.Messages;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Logging.Interface;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models.Read;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class GraphUpdateViewModelTests
+{
+    [Test]
+    public void GraphsSelectedMessage_ShouldPopulateSelection()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var serviceMock = new Mock<IGraphInfoRequestService>();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+        neighborhoodFactoryMock.SetupGet(x => x.Allowed)
+            .Returns(new[] { Neighborhoods.Moore, Neighborhoods.Diagonal });
+
+        using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
+
+        var model = Generators.GenerateGraphInfos(1).Single();
+        messenger.Send(new GraphsSelectedMessage([model]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.SelectedGraphs, Has.Length.EqualTo(1));
+            Assert.That(viewModel.Name, Is.EqualTo(model.Name));
+            Assert.That(viewModel.Neighborhood, Is.EqualTo(model.Neighborhood));
+            Assert.That(viewModel.Status, Is.EqualTo(model.Status));
+        });
+    }
+
+    [Test]
+    public void GraphsDeletedMessage_ShouldClearNameWhenSelectionRemoved()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var serviceMock = new Mock<IGraphInfoRequestService>();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+        neighborhoodFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Neighborhoods>());
+
+        using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
+
+        var model = Generators.GenerateGraphInfos(1).Single();
+        viewModel.SelectedGraphs = [model];
+        viewModel.Name = "Graph";
+
+        messenger.Send(new GraphsDeletedMessage([model.Id]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewModel.SelectedGraphs, Is.Empty);
+            Assert.That(viewModel.Name, Is.EqualTo(string.Empty));
+        });
+    }
+
+    [Test]
+    public async Task UpdateGraphCommand_ShouldUpdateGraphAndNotifyAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var serviceMock = new Mock<IGraphInfoRequestService>();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+        neighborhoodFactoryMock.SetupGet(x => x.Allowed)
+            .Returns(new[] { Neighborhoods.Moore });
+
+        var graphInfoModel = Generators.GenerateGraphInfos(1).Single();
+        var newName = graphInfoModel.Name + "_updated";
+        var graphInformation = new GraphInformationModel
+        {
+            Id = graphInfoModel.Id,
+            Name = graphInfoModel.Name,
+            Neighborhood = graphInfoModel.Neighborhood,
+            Status = graphInfoModel.Status,
+            Dimensions = []
+        };
+
+        serviceMock
+            .Setup(x => x.ReadGraphInfoAsync(
+                graphInfoModel.Id,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(graphInformation);
+
+        serviceMock
+            .Setup(x => x.UpdateGraphInfoAsync(
+                It.IsAny<GraphInformationModel>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var graphTableMessages = new List<AwaitGraphUpdatedMessage>();
+        messenger.Register<AwaitGraphUpdatedMessage, int>(this, Tokens.GraphTable, (_, msg) =>
+        {
+            graphTableMessages.Add(msg);
+            msg.SetCompleted();
+        });
+
+        var algorithmUpdateMessages = new List<AwaitGraphUpdatedMessage>();
+        messenger.Register<AwaitGraphUpdatedMessage, int>(this, Tokens.AlgorithmUpdate, (_, msg) =>
+        {
+            algorithmUpdateMessages.Add(msg);
+            msg.SetCompleted();
+        });
+
+        GraphUpdatedMessage broadcastMessage = null;
+        messenger.Register<GraphUpdatedMessage>(this, (_, msg) => broadcastMessage = msg);
+
+        using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
+
+        messenger.Send(new GraphsSelectedMessage([graphInfoModel]));
+        viewModel.Name = newName;
+        viewModel.Neighborhood = Neighborhoods.Moore;
+
+        await viewModel.UpdateGraphCommand.Execute();
+
+        Assert.Multiple(() =>
+        {
+            serviceMock.Verify(x => x.ReadGraphInfoAsync(
+                graphInfoModel.Id,
+                It.IsAny<CancellationToken>()), Times.Once);
+            serviceMock.Verify(x => x.UpdateGraphInfoAsync(
+                It.Is<GraphInformationModel>(model
+                    => model.Id == graphInfoModel.Id
+                       && model.Name == newName
+                       && model.Neighborhood == Neighborhoods.Moore),
+                It.IsAny<CancellationToken>()), Times.Once);
+            Assert.That(graphTableMessages, Has.Count.EqualTo(1));
+            Assert.That(algorithmUpdateMessages, Has.Count.EqualTo(1));
+            Assert.That(broadcastMessage, Is.Not.Null);
+        });
+    }
+
+    private static GraphUpdateViewModel CreateViewModel(
+        IMessenger messenger,
+        Mock<IGraphInfoRequestService> serviceMock,
+        Mock<INeighborhoodLayerFactory> neighborhoodFactoryMock,
+        ILog log = null)
+    {
+        return new GraphUpdateViewModel(
+            serviceMock.Object,
+            neighborhoodFactoryMock.Object,
+            messenger,
+            log ?? Mock.Of<ILog>());
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
@@ -1,0 +1,193 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Factories;
+using Pathfinding.App.Console.Messages.ViewModel.Requests;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Logging.Interface;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models.Read;
+using Pathfinding.Service.Interface.Models.Undefined;
+using Pathfinding.Service.Interface.Requests.Create;
+using Pathfinding.Shared.Primitives;
+using System.Reactive.Linq;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class RunCreateViewModelTests
+{
+    [Test]
+    public async Task GraphLifecycle_ShouldToggleCommandAvailabilityAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            heuristicsFactoryMock,
+            stepRuleFactoryMock);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 42)));
+
+        viewModel.Algorithm = Algorithms.AStar;
+
+        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(x => x), Is.True);
+
+        messenger.Send(new GraphsDeletedMessage([42]));
+
+        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(x => !x), Is.True);
+    }
+
+    [Test]
+    public async Task CreateRunCommand_ShouldRequestStatisticsAndPublishMessageAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+        var logMock = new Mock<ILog>();
+
+        var createdRuns = new[]
+        {
+            new RunStatisticsModel { Id = 1, GraphId = 42, Algorithm = Algorithms.AStar }
+        };
+
+        statisticsServiceMock
+            .Setup(x => x.CreateStatisticsAsync(
+                It.IsAny<IEnumerable<CreateStatisticsRequest>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(createdRuns);
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            heuristicsFactoryMock,
+            stepRuleFactoryMock,
+            logMock.Object);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 42)));
+
+        messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
+            => msg.Reply(graph.Select(v => v).ToArray()));
+
+        viewModel.Algorithm = Algorithms.AStar;
+
+        RunsCreatedMessaged createdMessage = null;
+        messenger.Register<RunsCreatedMessaged>(this, (_, msg) => createdMessage = msg);
+
+        await viewModel.CreateRunCommand.Execute();
+
+        Assert.Multiple(() =>
+        {
+            statisticsServiceMock.Verify(x => x.CreateStatisticsAsync(
+                It.Is<IEnumerable<CreateStatisticsRequest>>(requests => requests.Any()),
+                It.IsAny<CancellationToken>()), Times.Once);
+            Assert.That(createdMessage, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public async Task CreateRunCommand_RangeTooSmall_ShouldLogInformationAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+        var logMock = new Mock<ILog>();
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            heuristicsFactoryMock,
+            stepRuleFactoryMock,
+            logMock.Object);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 42)));
+
+        messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
+            => msg.Reply(new[] { graph.First() }));
+
+        viewModel.Algorithm = Algorithms.AStar;
+
+        await viewModel.CreateRunCommand.Execute();
+
+        statisticsServiceMock.Verify(x => x.CreateStatisticsAsync(
+            It.IsAny<IEnumerable<CreateStatisticsRequest>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        logMock.Verify(x => x.Info(It.IsAny<string>()), Times.Once);
+    }
+
+    private static RunCreateViewModel CreateViewModel(
+        IMessenger messenger,
+        Mock<IStatisticsRequestService> statisticsServiceMock,
+        Mock<IAlgorithmsFactory> algorithmsFactoryMock,
+        Mock<IHeuristicsFactory> heuristicsFactoryMock,
+        Mock<IStepRuleFactory> stepRuleFactoryMock,
+        ILog log = null)
+    {
+        return new RunCreateViewModel(
+            statisticsServiceMock.Object,
+            algorithmsFactoryMock.Object,
+            heuristicsFactoryMock.Object,
+            stepRuleFactoryMock.Object,
+            messenger,
+            log ?? Mock.Of<ILog>());
+    }
+
+    private static Mock<IAlgorithmsFactory> CreateAlgorithmsFactoryMock()
+    {
+        var factory = new TestAlgorithmFactory();
+        var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock
+            .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
+            .Returns(factory);
+        return algorithmsFactoryMock;
+    }
+
+    private static Graph<GraphVertexModel> CreateGraph()
+    {
+        var first = new GraphVertexModel { Position = new Coordinate(0) };
+        var second = new GraphVertexModel { Position = new Coordinate(1) };
+        first.Neighbors.Add(second);
+        second.Neighbors.Add(first);
+        return new Graph<GraphVertexModel>([first, second], [2]);
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
@@ -27,9 +27,9 @@ internal sealed class RunCreateViewModelTests
         var statisticsServiceMock = new Mock<IStatisticsRequestService>();
         var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
         var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
-        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns([]);
         var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
-        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns([]);
 
         using var viewModel = CreateViewModel(
             messenger,
@@ -43,16 +43,16 @@ internal sealed class RunCreateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 42)));
+            GraphStatuses.Editable,
+            GraphId: 42)));
 
         viewModel.Algorithm = Algorithms.AStar;
 
-        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(x => x), Is.True);
+        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(), Is.True);
 
         messenger.Send(new GraphsDeletedMessage([42]));
 
-        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(x => !x), Is.True);
+        Assert.That(await viewModel.CreateRunCommand.CanExecute.FirstAsync(), Is.False);
     }
 
     [Test]
@@ -62,9 +62,9 @@ internal sealed class RunCreateViewModelTests
         var statisticsServiceMock = new Mock<IStatisticsRequestService>();
         var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
         var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
-        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns([]);
         var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
-        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns([]);
         var logMock = new Mock<ILog>();
 
         var createdRuns = new[]
@@ -91,11 +91,11 @@ internal sealed class RunCreateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 42)));
+            GraphStatuses.Editable,
+            GraphId: 42)));
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
-            => msg.Reply(graph.Select(v => v).ToArray()));
+            => msg.Reply([.. graph.Select(v => v)]));
 
         viewModel.Algorithm = Algorithms.AStar;
 
@@ -120,9 +120,9 @@ internal sealed class RunCreateViewModelTests
         var statisticsServiceMock = new Mock<IStatisticsRequestService>();
         var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
         var heuristicsFactoryMock = new Mock<IHeuristicsFactory>();
-        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<Heuristics>());
+        heuristicsFactoryMock.SetupGet(x => x.Allowed).Returns([]);
         var stepRuleFactoryMock = new Mock<IStepRuleFactory>();
-        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns(Array.Empty<StepRules>());
+        stepRuleFactoryMock.SetupGet(x => x.Allowed).Returns([]);
         var logMock = new Mock<ILog>();
 
         using var viewModel = CreateViewModel(
@@ -138,11 +138,11 @@ internal sealed class RunCreateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 42)));
+            GraphStatuses.Editable,
+            GraphId: 42)));
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
-            => msg.Reply(new[] { graph.First() }));
+            => msg.Reply([graph.First()]));
 
         viewModel.Algorithm = Algorithms.AStar;
 
@@ -175,7 +175,7 @@ internal sealed class RunCreateViewModelTests
     {
         var factory = new TestAlgorithmFactory();
         var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
-        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns([Algorithms.AStar]);
         algorithmsFactoryMock
             .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
             .Returns(factory);

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
@@ -1,0 +1,121 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Factories;
+using Pathfinding.App.Console.Messages.ViewModel.Requests;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Domain.Interface.Factories;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Service.Interface.Models.Read;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class RunFieldViewModelTests
+{
+    [Test]
+    public void GraphActivatedMessage_ShouldAssembleRunGraph()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphAssemble = new GraphAssemble<RunVertexModel>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+
+        using var viewModel = new RunFieldViewModel(
+            graphAssemble,
+            algorithmsFactoryMock.Object,
+            messenger);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 1)));
+
+        Assert.That(viewModel.RunGraph, Is.Not.EqualTo(Graph<RunVertexModel>.Empty));
+    }
+
+    [Test]
+    public void RunsSelectedMessage_ShouldActivateRun()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphAssemble = new GraphAssemble<RunVertexModel>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+
+        using var viewModel = new RunFieldViewModel(
+            graphAssemble,
+            algorithmsFactoryMock.Object,
+            messenger);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 1)));
+
+        messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
+            => msg.Reply(graph.ToArray()));
+
+        var runInfo = new RunInfoModel { Id = 7, Algorithm = Algorithms.AStar };
+        messenger.Send(new RunsSelectedMessage([runInfo]));
+
+        Assert.That(viewModel.SelectedRun.Id, Is.EqualTo(runInfo.Id));
+    }
+
+    [Test]
+    public void RunsDeletedMessage_ShouldClearSelectedRun()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphAssemble = new GraphAssemble<RunVertexModel>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+
+        using var viewModel = new RunFieldViewModel(
+            graphAssemble,
+            algorithmsFactoryMock.Object,
+            messenger);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 1)));
+
+        messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
+            => msg.Reply(graph.ToArray()));
+
+        var runInfo = new RunInfoModel { Id = 4, Algorithm = Algorithms.AStar };
+        messenger.Send(new RunsSelectedMessage([runInfo]));
+
+        messenger.Send(new RunsDeletedMessage([runInfo.Id]));
+
+        Assert.That(viewModel.SelectedRun, Is.EqualTo(RunModel.Empty));
+    }
+
+    private static Graph<GraphVertexModel> CreateGraph()
+    {
+        var first = new GraphVertexModel { Position = new Coordinate(0) };
+        var second = new GraphVertexModel { Position = new Coordinate(1) };
+        first.Neighbors.Add(second);
+        second.Neighbors.Add(first);
+        return new Graph<GraphVertexModel>([first, second], [2]);
+    }
+
+    private static Mock<IAlgorithmsFactory> CreateAlgorithmsFactoryMock()
+    {
+        var factory = new TestAlgorithmFactory();
+        var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock
+            .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
+            .Returns(factory);
+        return algorithmsFactoryMock;
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
@@ -33,8 +33,8 @@ internal sealed class RunFieldViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 1)));
+            GraphStatuses.Editable,
+            GraphId: 1)));
 
         Assert.That(viewModel.RunGraph, Is.Not.EqualTo(Graph<RunVertexModel>.Empty));
     }
@@ -56,11 +56,11 @@ internal sealed class RunFieldViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 1)));
+            GraphStatuses.Editable,
+            GraphId: 1)));
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
-            => msg.Reply(graph.ToArray()));
+            => msg.Reply([.. graph]));
 
         var runInfo = new RunInfoModel { Id = 7, Algorithm = Algorithms.AStar };
         messenger.Send(new RunsSelectedMessage([runInfo]));
@@ -85,11 +85,11 @@ internal sealed class RunFieldViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 1)));
+            GraphStatuses.Editable,
+            GraphId: 1)));
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
-            => msg.Reply(graph.ToArray()));
+            => msg.Reply([.. graph]));
 
         var runInfo = new RunInfoModel { Id = 4, Algorithm = Algorithms.AStar };
         messenger.Send(new RunsSelectedMessage([runInfo]));
@@ -101,8 +101,8 @@ internal sealed class RunFieldViewModelTests
 
     private static Graph<GraphVertexModel> CreateGraph()
     {
-        var first = new GraphVertexModel { Position = new Coordinate(0) };
-        var second = new GraphVertexModel { Position = new Coordinate(1) };
+        var first = new GraphVertexModel { Position = new Coordinate(0), Cost = new VertexCost(1, (1,2)) };
+        var second = new GraphVertexModel { Position = new Coordinate(1), Cost = new VertexCost(3, (2, 4)) };
         first.Neighbors.Add(second);
         second.Neighbors.Add(first);
         return new Graph<GraphVertexModel>([first, second], [2]);
@@ -112,7 +112,7 @@ internal sealed class RunFieldViewModelTests
     {
         var factory = new TestAlgorithmFactory();
         var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
-        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns([Algorithms.AStar]);
         algorithmsFactoryMock
             .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
             .Returns(factory);

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunRangeViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunRangeViewModelTests.cs
@@ -1,0 +1,191 @@
+using Autofac.Features.Metadata;
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Injection;
+using Pathfinding.App.Console.Messages;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Logging.Interface;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models.Read;
+using Pathfinding.Shared.Primitives;
+using System.Collections.Generic;
+using Command = Pathfinding.Service.Interface.IPathfindingRangeCommand<Pathfinding.App.Console.Models.GraphVertexModel>;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class RunRangeViewModelTests
+{
+    [Test]
+    public void AddToRangeCommand_ShouldExecuteFirstAvailableCommand()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        var includeCommands = new[]
+        {
+            CreateCommandMeta(new StubCommand(canExecute: false)),
+            CreateCommandMeta(new StubCommand(canExecute: true,
+                execute: (range, vertex) => range.Source = vertex))
+        };
+        var excludeCommands = Array.Empty<Meta<Command>>();
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            rangeServiceMock,
+            includeCommands,
+            excludeCommands);
+
+        var vertex = new GraphVertexModel { Position = new Coordinate(0) };
+        viewModel.AddToRangeCommand.Execute(vertex);
+
+        Assert.That(viewModel.Source, Is.EqualTo(vertex));
+    }
+
+    [Test]
+    public void RemoveFromRangeCommand_ShouldExecuteFirstAvailableCommand()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        var includeCommands = new[]
+        {
+            CreateCommandMeta(new StubCommand(canExecute: true,
+                execute: (range, vertex) => range.Source = vertex))
+        };
+        var excludeCommands = new[]
+        {
+            CreateCommandMeta(new StubCommand(canExecute: true,
+                execute: (range, _) => range.Source = null))
+        };
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            rangeServiceMock,
+            includeCommands,
+            excludeCommands);
+
+        var vertex = new GraphVertexModel { Position = new Coordinate(0) };
+        viewModel.AddToRangeCommand.Execute(vertex);
+        viewModel.RemoveFromRangeCommand.Execute(vertex);
+
+        Assert.That(viewModel.Source, Is.Null);
+    }
+
+    [Test]
+    public async Task DeletePathfindingRange_ShouldClearStoredRangeAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        rangeServiceMock
+            .Setup(x => x.ReadRangeAsync(
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PathfindingRangeModel>
+            {
+                new() { Position = new Coordinate(0), IsSource = true },
+                new() { Position = new Coordinate(1), IsTarget = true }
+            });
+
+        rangeServiceMock
+            .Setup(x => x.DeleteRangeAsync(
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var includeCommands = new[]
+        {
+            CreateCommandMeta(new StubCommand(canExecute: true,
+                execute: (range, vertex) =>
+                {
+                    if (range.Source == null) range.Source = vertex;
+                    else range.Target = vertex;
+                }))
+        };
+        var excludeCommands = Array.Empty<Meta<Command>>();
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            rangeServiceMock,
+            includeCommands,
+            excludeCommands);
+
+        var graph = CreateGraph();
+        await messenger.Send(new AwaitGraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 12)), Tokens.PathfindingRange);
+
+        Assert.That(viewModel.Source, Is.Not.Null);
+        Assert.That(viewModel.Target, Is.Not.Null);
+
+        await viewModel.DeletePathfindingRange.Execute();
+
+        Assert.Multiple(() =>
+        {
+            rangeServiceMock.Verify(x => x.DeleteRangeAsync(12, It.IsAny<CancellationToken>()), Times.Once);
+            Assert.That(viewModel.Source, Is.Null);
+            Assert.That(viewModel.Target, Is.Null);
+            Assert.That(viewModel.Transit, Is.Empty);
+        });
+    }
+
+    private static RunRangeViewModel CreateViewModel(
+        IMessenger messenger,
+        Mock<IRangeRequestService<GraphVertexModel>> rangeServiceMock,
+        Meta<Command>[] includeCommands,
+        Meta<Command>[] excludeCommands,
+        ILog log = null)
+    {
+        return new RunRangeViewModel(
+            messenger,
+            includeCommands,
+            excludeCommands,
+            rangeServiceMock.Object,
+            log ?? Mock.Of<ILog>());
+    }
+
+    private static Graph<GraphVertexModel> CreateGraph()
+    {
+        var first = new GraphVertexModel { Position = new Coordinate(0) };
+        var second = new GraphVertexModel { Position = new Coordinate(1) };
+        first.Neighbors.Add(second);
+        second.Neighbors.Add(first);
+        return new Graph<GraphVertexModel>([first, second], [2]);
+    }
+
+    private static Meta<Command> CreateCommandMeta(Command command, int order = 1)
+    {
+        var metadata = new Dictionary<string, object>
+        {
+            [MetadataKeys.Order] = order
+        };
+        return new Meta<Command>(command, metadata);
+    }
+
+    private sealed class StubCommand : Command
+    {
+        private readonly bool canExecute;
+        private readonly Action<IPathfindingRange<GraphVertexModel>, GraphVertexModel> execute;
+
+        public StubCommand(bool canExecute, Action<IPathfindingRange<GraphVertexModel>, GraphVertexModel> execute = null)
+        {
+            this.canExecute = canExecute;
+            this.execute = execute ?? ((_, _) => { });
+        }
+
+        public void Execute(IPathfindingRange<GraphVertexModel> range, GraphVertexModel vertex)
+        {
+            execute(range, vertex);
+        }
+
+        public bool CanExecute(IPathfindingRange<GraphVertexModel> range, GraphVertexModel vertex)
+        {
+            return canExecute;
+        }
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
@@ -1,0 +1,200 @@
+using CommunityToolkit.Mvvm.Messaging;
+using Moq;
+using Pathfinding.App.Console.Factories;
+using Pathfinding.App.Console.Messages;
+using Pathfinding.App.Console.Messages.ViewModel.ValueMessages;
+using Pathfinding.App.Console.Models;
+using Pathfinding.App.Console.ViewModels;
+using Pathfinding.Domain.Core.Enums;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Logging.Interface;
+using Pathfinding.Service.Interface;
+using Pathfinding.Service.Interface.Models.Read;
+using Pathfinding.Service.Interface.Models.Undefined;
+using Pathfinding.Shared.Primitives;
+using System.Reactive.Linq;
+
+namespace Pathfinding.App.Console.Tests.ViewModelTests;
+
+[Category("Unit")]
+internal sealed class RunUpdateViewModelTests
+{
+    [Test]
+    public async Task RunsSelectedMessage_ShouldEnableUpdateCommandAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphServiceMock = new Mock<IGraphRequestService<GraphVertexModel>>();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            graphServiceMock,
+            rangeServiceMock,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            neighborhoodFactoryMock);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 10)));
+
+        var runInfo = new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar };
+        messenger.Send(new RunsSelectedMessage([runInfo]));
+
+        Assert.That(await viewModel.UpdateRunsCommand.CanExecute.FirstAsync(x => x), Is.True);
+    }
+
+    [Test]
+    public async Task UpdateRunsCommand_ShouldRefreshStatisticsAndNotifyAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphServiceMock = new Mock<IGraphRequestService<GraphVertexModel>>();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+
+        var graph = CreateGraph();
+        var range = new[]
+        {
+            new PathfindingRangeModel { Position = new Coordinate(0), IsSource = true },
+            new PathfindingRangeModel { Position = new Coordinate(1), IsTarget = true }
+        };
+
+        rangeServiceMock
+            .Setup(x => x.ReadRangeAsync(
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(range);
+
+        statisticsServiceMock
+            .Setup(x => x.ReadStatisticsAsync(
+                It.IsAny<IEnumerable<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<RunStatisticsModel>
+            {
+                new() { Id = 1, GraphId = 10, Algorithm = Algorithms.AStar }
+            });
+
+        statisticsServiceMock
+            .Setup(x => x.UpdateStatisticsAsync(
+                It.IsAny<IEnumerable<RunStatisticsModel>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            graphServiceMock,
+            rangeServiceMock,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            neighborhoodFactoryMock);
+
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 10)));
+
+        var runInfo = new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar };
+        messenger.Send(new RunsSelectedMessage([runInfo]));
+
+        RunsUpdatedMessage updatedMessage = null;
+        messenger.Register<RunsUpdatedMessage>(this, (_, msg) => updatedMessage = msg);
+
+        await viewModel.UpdateRunsCommand.Execute();
+
+        Assert.Multiple(() =>
+        {
+            statisticsServiceMock.Verify(x => x.ReadStatisticsAsync(
+                It.IsAny<IEnumerable<int>>(),
+                It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+            statisticsServiceMock.Verify(x => x.UpdateStatisticsAsync(
+                It.IsAny<IEnumerable<RunStatisticsModel>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+            Assert.That(updatedMessage, Is.Not.Null);
+        });
+    }
+
+    [Test]
+    public async Task GraphsDeletedMessage_ShouldClearSelectionAsync()
+    {
+        var messenger = new StrongReferenceMessenger();
+        var graphServiceMock = new Mock<IGraphRequestService<GraphVertexModel>>();
+        var rangeServiceMock = new Mock<IRangeRequestService<GraphVertexModel>>();
+        var statisticsServiceMock = new Mock<IStatisticsRequestService>();
+        var algorithmsFactoryMock = CreateAlgorithmsFactoryMock();
+        var neighborhoodFactoryMock = new Mock<INeighborhoodLayerFactory>();
+
+        using var viewModel = CreateViewModel(
+            messenger,
+            graphServiceMock,
+            rangeServiceMock,
+            statisticsServiceMock,
+            algorithmsFactoryMock,
+            neighborhoodFactoryMock);
+
+        var graph = CreateGraph();
+        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+            graph,
+            Neighborhoods.Moore,
+            SmoothLevels.No,
+            GraphStatuses.Active,
+            graphId: 5)));
+
+        messenger.Send(new RunsSelectedMessage([
+            new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar }
+        ]));
+
+        messenger.Send(new GraphsDeletedMessage([5]));
+
+        Assert.That(await viewModel.UpdateRunsCommand.CanExecute.FirstAsync(x => !x), Is.True);
+    }
+
+    private static RunUpdateViewModel CreateViewModel(
+        IMessenger messenger,
+        Mock<IGraphRequestService<GraphVertexModel>> graphServiceMock,
+        Mock<IRangeRequestService<GraphVertexModel>> rangeServiceMock,
+        Mock<IStatisticsRequestService> statisticsServiceMock,
+        Mock<IAlgorithmsFactory> algorithmsFactoryMock,
+        Mock<INeighborhoodLayerFactory> neighborhoodFactoryMock,
+        ILog log = null)
+    {
+        return new RunUpdateViewModel(
+            graphServiceMock.Object,
+            rangeServiceMock.Object,
+            statisticsServiceMock.Object,
+            algorithmsFactoryMock.Object,
+            neighborhoodFactoryMock.Object,
+            messenger,
+            log ?? Mock.Of<ILog>());
+    }
+
+    private static Mock<IAlgorithmsFactory> CreateAlgorithmsFactoryMock()
+    {
+        var factory = new TestAlgorithmFactory();
+        var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock
+            .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
+            .Returns(factory);
+        return algorithmsFactoryMock;
+    }
+
+    private static Graph<GraphVertexModel> CreateGraph()
+    {
+        var first = new GraphVertexModel { Position = new Coordinate(0) };
+        var second = new GraphVertexModel { Position = new Coordinate(1) };
+        first.Neighbors.Add(second);
+        second.Neighbors.Add(first);
+        return new Graph<GraphVertexModel>([first, second], [2]);
+    }
+}

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
@@ -42,8 +42,8 @@ internal sealed class RunUpdateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 10)));
+            GraphStatuses.Editable,
+            GraphId: 10)));
 
         var runInfo = new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar };
         messenger.Send(new RunsSelectedMessage([runInfo]));
@@ -78,10 +78,10 @@ internal sealed class RunUpdateViewModelTests
             .Setup(x => x.ReadStatisticsAsync(
                 It.IsAny<IEnumerable<int>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<RunStatisticsModel>
-            {
+            .ReturnsAsync(
+            [
                 new() { Id = 1, GraphId = 10, Algorithm = Algorithms.AStar }
-            });
+            ]);
 
         statisticsServiceMock
             .Setup(x => x.UpdateStatisticsAsync(
@@ -101,8 +101,8 @@ internal sealed class RunUpdateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 10)));
+            GraphStatuses.Editable,
+            GraphId: 10)));
 
         var runInfo = new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar };
         messenger.Send(new RunsSelectedMessage([runInfo]));
@@ -147,8 +147,8 @@ internal sealed class RunUpdateViewModelTests
             graph,
             Neighborhoods.Moore,
             SmoothLevels.No,
-            GraphStatuses.Active,
-            graphId: 5)));
+            GraphStatuses.Editable,
+            GraphId: 5)));
 
         messenger.Send(new RunsSelectedMessage([
             new RunInfoModel { Id = 1, Algorithm = Algorithms.AStar }
@@ -156,7 +156,7 @@ internal sealed class RunUpdateViewModelTests
 
         messenger.Send(new GraphsDeletedMessage([5]));
 
-        Assert.That(await viewModel.UpdateRunsCommand.CanExecute.FirstAsync(x => !x), Is.True);
+        Assert.That(await viewModel.UpdateRunsCommand.CanExecute.FirstAsync(), Is.False);
     }
 
     private static RunUpdateViewModel CreateViewModel(
@@ -182,7 +182,7 @@ internal sealed class RunUpdateViewModelTests
     {
         var factory = new TestAlgorithmFactory();
         var algorithmsFactoryMock = new Mock<IAlgorithmsFactory>();
-        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns(new[] { Algorithms.AStar });
+        algorithmsFactoryMock.SetupGet(x => x.Allowed).Returns([Algorithms.AStar]);
         algorithmsFactoryMock
             .Setup(x => x.GetAlgorithmFactory(It.IsAny<Algorithms>()))
             .Returns(factory);


### PR DESCRIPTION
## Summary
- add a reusable stub pathfinding process for view model testing
- cover graph update and import console view models with unit tests
- add unit tests for run create, update, field, and range view models

## Testing
- dotnet test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f42bb94288333aa899f1a3190abb7)