### PR TITLE
Add unit tests for pathfinding algorithms

### DIFF
--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class AStarAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_RespectsHeuristicAndCost()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new AStarAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarGreedyAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarGreedyAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class AStarGreedyAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_PrefersLowerEstimatedCost()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new AStarGreedyAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarLeeAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/AStarLeeAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class AStarLeeAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_ExpandsUsingHeuristicQueue()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new AStarLeeAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectAStarAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectAStarAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class BidirectAStarAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_CombinesFrontiersAtMeetingPoint()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new BidirectAStarAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectAStarAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectAStarAlgorithmTests.cs
@@ -14,6 +14,6 @@ public class BidirectAStarAlgorithmTests
 
         var path = algorithm.FindPath();
 
-        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 3, expectedCost: 3);
     }
 }

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectDijkstraAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectDijkstraAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class BidirectDijkstraAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_FindsShortestIntersection()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new BidirectDijkstraAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectDijkstraAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectDijkstraAlgorithmTests.cs
@@ -14,6 +14,6 @@ public class BidirectDijkstraAlgorithmTests
 
         var path = algorithm.FindPath();
 
-        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 3, expectedCost: 3);
     }
 }

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectLeeAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectLeeAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class BidirectLeeAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_UsesQueueFrontiers()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new BidirectLeeAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectRandomAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/BidirectRandomAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class BidirectRandomAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_DoesNotThrowAndReturnsPath()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new BidirectRandomAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/CostGreedyAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/CostGreedyAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class CostGreedyAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_UsesStepCostAsHeuristic()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new CostGreedyAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DepthFirstAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DepthFirstAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class DepthFirstAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_TraversesToTarget()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new DepthFirstAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DepthRandomAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DepthRandomAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class DepthRandomAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_HandlesRandomSelection()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new DepthRandomAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DijkstraAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DijkstraAlgorithmTests.cs
@@ -1,0 +1,20 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Algorithms.StepRules;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class DijkstraAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_ChoosesLowestCostRoute()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new DijkstraAlgorithm(graph.Range, new DefaultStepRule());
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DistanceFirstAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/DistanceFirstAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class DistanceFirstAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithBranchingGraph_PrefersCloserVertex()
+    {
+        var graph = TestGraphFactory.CreateBranchingGraph();
+        var algorithm = new DistanceFirstAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Events/SubPathFoundEventArgsTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Events/SubPathFoundEventArgsTests.cs
@@ -1,0 +1,18 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Events;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Events;
+
+[Category("Unit")]
+public class SubPathFoundEventArgsTests
+{
+    [Test]
+    public void Constructor_ExposesSubPath()
+    {
+        var subPath = NullGraphPath.Instance;
+
+        var args = new SubPathFoundEventArgs(subPath);
+
+        Assert.That(args.SubPath, Is.SameAs(subPath));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Events/VerticesProcessedEventArgsTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Events/VerticesProcessedEventArgsTests.cs
@@ -1,0 +1,26 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Events;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Events;
+
+[Category("Unit")]
+public class VerticesProcessedEventArgsTests
+{
+    [Test]
+    public void Constructor_StoresCurrentAndEnqueuedCoordinates()
+    {
+        var current = new TestPathfindingVertex(new Coordinate(0, 0));
+        var first = new TestPathfindingVertex(new Coordinate(1, 0));
+        var second = new TestPathfindingVertex(new Coordinate(2, 0));
+
+        var args = new VerticesProcessedEventArgs(current, new[] { first, second });
+
+        Assert.That(args.Current, Is.EqualTo(current.Position));
+        Assert.That(args.Enqueued, Is.EqualTo(new[]
+        {
+            first.Position,
+            second.Position
+        }));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Exceptions/DeadendVertexExceptionTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Exceptions/DeadendVertexExceptionTests.cs
@@ -1,0 +1,25 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Exceptions;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Exceptions;
+
+[Category("Unit")]
+public class DeadendVertexExceptionTests
+{
+    [Test]
+    public void DefaultConstructor_UsesPredefinedMessage()
+    {
+        var exception = new DeadendVertexException();
+
+        Assert.That(exception.Message, Is.EqualTo("Can't reach the destination"));
+    }
+
+    [Test]
+    public void MessageConstructor_OverridesDefaultMessage()
+    {
+        const string message = "custom";
+
+        var exception = new DeadendVertexException(message);
+
+        Assert.That(exception.Message, Is.EqualTo(message));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Exceptions/PathfindingExceptionTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Exceptions/PathfindingExceptionTests.cs
@@ -1,0 +1,25 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Exceptions;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Exceptions;
+
+[Category("Unit")]
+public class PathfindingExceptionTests
+{
+    [Test]
+    public void DefaultConstructor_SetsInnerExceptionToNull()
+    {
+        var exception = new PathfindingException();
+
+        Assert.That(exception.InnerException, Is.Null);
+    }
+
+    [Test]
+    public void MessageConstructor_StoresMessage()
+    {
+        const string message = "custom";
+
+        var exception = new PathfindingException(message);
+
+        Assert.That(exception.Message, Is.EqualTo(message));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/BidirectGraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/BidirectGraphPathTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.GraphPaths;
+
+[Category("Unit")]
+public class BidirectGraphPathTests
+{
+    [Test]
+    public void BidirectGraphPath_CombinesForwardAndBackwardTraces()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var middle = graph.Vertices.Single(v => v.Position.Equals(new Coordinate(1, 0)));
+
+        var forwardTraces = new Dictionary<Coordinate, IPathfindingVertex>
+        {
+            [middle.Position] = graph.Start
+        };
+        var backwardTraces = new Dictionary<Coordinate, IPathfindingVertex>
+        {
+            [middle.Position] = graph.Target
+        };
+
+        var path = new BidirectGraphPath(forwardTraces, backwardTraces, middle);
+
+        Assert.That(path.Count, Is.EqualTo(2));
+        Assert.That(path.Cost, Is.EqualTo(2));
+
+        var coordinates = path.ToList();
+        Assert.That(coordinates, Is.EquivalentTo(new[]
+        {
+            graph.Target.Position,
+            middle.Position
+        }));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/BidirectGraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/BidirectGraphPathTests.cs
@@ -27,7 +27,7 @@ public class BidirectGraphPathTests
 
         var path = new BidirectGraphPath(forwardTraces, backwardTraces, middle);
 
-        Assert.That(path.Count, Is.EqualTo(2));
+        Assert.That(path, Has.Count.EqualTo(2));
         Assert.That(path.Cost, Is.EqualTo(2));
 
         var coordinates = path.ToList();

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/CompositeGraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/CompositeGraphPathTests.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.GraphPaths;
+
+[Category("Unit")]
+public class CompositeGraphPathTests
+{
+    [Test]
+    public void CompositeGraphPath_AggregatesCostAndCount()
+    {
+        var first = new FakeGraphPath([
+            new Coordinate(2, 0),
+            new Coordinate(1, 0)
+        ], count: 2, cost: 3);
+        var second = new FakeGraphPath([
+            new Coordinate(1, 0),
+            new Coordinate(0, 0)
+        ], count: 1, cost: 1);
+
+        var composite = new CompositeGraphPath(new[] { first, second });
+
+        Assert.That(composite.Count, Is.EqualTo(3));
+        Assert.That(composite.Cost, Is.EqualTo(4));
+        Assert.That(composite.ToList(), Is.EqualTo(new[]
+        {
+            new Coordinate(1, 0),
+            new Coordinate(2, 0),
+            new Coordinate(0, 0),
+            new Coordinate(1, 0)
+        }));
+    }
+
+    private sealed class FakeGraphPath : IGraphPath
+    {
+        private readonly IReadOnlyList<Coordinate> coordinates;
+
+        public FakeGraphPath(IReadOnlyList<Coordinate> coordinates, int count, double cost)
+        {
+            this.coordinates = coordinates;
+            Count = count;
+            Cost = cost;
+        }
+
+        public double Cost { get; }
+
+        public int Count { get; }
+
+        public IEnumerator<Coordinate> GetEnumerator()
+        {
+            return coordinates.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/CompositeGraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/CompositeGraphPathTests.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+using Pathfinding.Service.Interface;
 using Pathfinding.Shared.Primitives;
 
 namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.GraphPaths;
@@ -21,33 +22,27 @@ public class CompositeGraphPathTests
             new Coordinate(0, 0)
         ], count: 1, cost: 1);
 
-        var composite = new CompositeGraphPath(new[] { first, second });
+        var composite = new CompositeGraphPath([first, second]);
 
-        Assert.That(composite.Count, Is.EqualTo(3));
-        Assert.That(composite.Cost, Is.EqualTo(4));
-        Assert.That(composite.ToList(), Is.EqualTo(new[]
+        Assert.That(composite, Has.Count.EqualTo(3));
+        Assert.Multiple(() =>
         {
+            Assert.That(composite.Cost, Is.EqualTo(4));
+            Assert.That(composite.ToList(), Is.EqualTo(new[]
+            {
             new Coordinate(1, 0),
             new Coordinate(2, 0),
             new Coordinate(0, 0),
             new Coordinate(1, 0)
         }));
+        });
     }
 
-    private sealed class FakeGraphPath : IGraphPath
+    private sealed class FakeGraphPath(IReadOnlyList<Coordinate> coordinates, int count, double cost) : IGraphPath
     {
-        private readonly IReadOnlyList<Coordinate> coordinates;
+        public double Cost { get; } = cost;
 
-        public FakeGraphPath(IReadOnlyList<Coordinate> coordinates, int count, double cost)
-        {
-            this.coordinates = coordinates;
-            Count = count;
-            Cost = cost;
-        }
-
-        public double Cost { get; }
-
-        public int Count { get; }
+        public int Count { get; } = count;
 
         public IEnumerator<Coordinate> GetEnumerator()
         {

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/GraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/GraphPathTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.GraphPaths;
+
+[Category("Unit")]
+public class GraphPathTests
+{
+    [Test]
+    public void GraphPath_BuildsSequenceFromTraces()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var middle = graph.Vertices.Single(v => v.Position.Equals(new Coordinate(1, 0)));
+        var traces = new Dictionary<Coordinate, IPathfindingVertex>
+        {
+            [graph.Target.Position] = middle,
+            [middle.Position] = graph.Start,
+        };
+
+        var path = new GraphPath(traces, graph.Target);
+
+        Assert.That(path.Count, Is.EqualTo(2));
+        Assert.That(path.Cost, Is.EqualTo(2));
+
+        var sequence = path.ToList();
+        Assert.That(sequence, Is.EqualTo(new[]
+        {
+            graph.Target.Position,
+            middle.Position,
+        }));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/GraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/GraphPathTests.cs
@@ -23,7 +23,7 @@ public class GraphPathTests
 
         var path = new GraphPath(traces, graph.Target);
 
-        Assert.That(path.Count, Is.EqualTo(2));
+        Assert.That(path, Has.Count.EqualTo(2));
         Assert.That(path.Cost, Is.EqualTo(2));
 
         var sequence = path.ToList();

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/NullGraphPathTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/GraphPaths/NullGraphPathTests.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+using Pathfinding.Infrastructure.Business.Algorithms.GraphPaths;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.GraphPaths;
+
+[Category("Unit")]
+public class NullGraphPathTests
+{
+    [Test]
+    public void NullGraphPath_HasZeroCostAndNoCoordinates()
+    {
+        var path = NullGraphPath.Instance;
+
+        Assert.That(path.Count, Is.EqualTo(0));
+        Assert.That(path.Cost, Is.EqualTo(0));
+        Assert.That(path.ToList(), Is.Empty);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/AlgorithmAssert.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/AlgorithmAssert.cs
@@ -10,7 +10,7 @@ internal static class AlgorithmAssert
 {
     public static IReadOnlyList<Coordinate> Enumerate(IGraphPath path)
     {
-        return path.ToList();
+        return [.. path];
     }
 
     public static void PathHasExpectedMetrics(
@@ -20,12 +20,15 @@ internal static class AlgorithmAssert
         double expectedCost,
         double tolerance = 1e-6)
     {
-        Assert.That(path.Count, Is.EqualTo(expectedLength));
+        Assert.That(path, Has.Count.EqualTo(expectedLength));
         Assert.That(path.Cost, Is.EqualTo(expectedCost).Within(tolerance));
 
         var coordinates = Enumerate(path);
-        Assert.That(coordinates.Count, Is.EqualTo(expectedLength));
-        Assert.That(coordinates[0], Is.EqualTo(graph.Target.Position));
-        Assert.That(coordinates, Does.Contain(graph.Target.Position));
+        Assert.That(coordinates, Has.Count.EqualTo(expectedLength));
+        Assert.Multiple(() =>
+        {
+            Assert.That(coordinates[0], Is.EqualTo(graph.Target.Position));
+            Assert.That(coordinates, Does.Contain(graph.Target.Position));
+        });
     }
 }

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/AlgorithmAssert.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/AlgorithmAssert.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Linq;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+internal static class AlgorithmAssert
+{
+    public static IReadOnlyList<Coordinate> Enumerate(IGraphPath path)
+    {
+        return path.ToList();
+    }
+
+    public static void PathHasExpectedMetrics(
+        IGraphPath path,
+        TestGraph graph,
+        int expectedLength,
+        double expectedCost,
+        double tolerance = 1e-6)
+    {
+        Assert.That(path.Count, Is.EqualTo(expectedLength));
+        Assert.That(path.Cost, Is.EqualTo(expectedCost).Within(tolerance));
+
+        var coordinates = Enumerate(path);
+        Assert.That(coordinates.Count, Is.EqualTo(expectedLength));
+        Assert.That(coordinates[0], Is.EqualTo(graph.Target.Position));
+        Assert.That(coordinates, Does.Contain(graph.Target.Position));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/TestGraphFactory.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/TestGraphFactory.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+internal static class TestGraphFactory
+{
+    public static TestGraph CreateLinearGraph()
+    {
+        var start = new TestPathfindingVertex(new Coordinate(0, 0));
+        var middle = new TestPathfindingVertex(new Coordinate(1, 0));
+        var target = new TestPathfindingVertex(new Coordinate(2, 0));
+
+        start.ConnectBidirectional(middle);
+        middle.ConnectBidirectional(target);
+
+        return new TestGraph(
+            start,
+            target,
+            new[] { start, middle, target });
+    }
+
+    public static TestGraph CreateBranchingGraph()
+    {
+        var start = new TestPathfindingVertex(new Coordinate(0, 0));
+        var cheapMiddle = new TestPathfindingVertex(new Coordinate(1, 0), cost: 1);
+        var expensiveMiddle = new TestPathfindingVertex(new Coordinate(0, 1), cost: 5);
+        var target = new TestPathfindingVertex(new Coordinate(2, 0));
+
+        start.ConnectBidirectional(cheapMiddle);
+        start.ConnectBidirectional(expensiveMiddle);
+        cheapMiddle.ConnectBidirectional(target);
+        expensiveMiddle.ConnectBidirectional(target);
+
+        return new TestGraph(
+            start,
+            target,
+            new IPathfindingVertex[] { start, cheapMiddle, expensiveMiddle, target });
+    }
+}
+
+internal sealed record TestGraph(
+    IPathfindingVertex Start,
+    IPathfindingVertex Target,
+    IReadOnlyCollection<IPathfindingVertex> Vertices)
+{
+    public IReadOnlyCollection<IPathfindingVertex> Range => new[] { Start, Target };
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/TestPathfindingVertex.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Helpers/TestPathfindingVertex.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using Pathfinding.Domain.Interface;
+using Pathfinding.Infrastructure.Data.Pathfinding;
+using Pathfinding.Service.Interface;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+internal sealed class TestPathfindingVertex : IPathfindingVertex
+{
+    private readonly List<IPathfindingVertex> neighbors = new();
+
+    public TestPathfindingVertex(Coordinate position, int cost = 1, bool isObstacle = false)
+    {
+        Position = position;
+        Cost = new VertexCost(cost, (1, 10));
+        IsObstacle = isObstacle;
+    }
+
+    public bool IsObstacle { get; set; }
+
+    public Coordinate Position { get; }
+
+    public IVertexCost Cost { get; }
+
+    public IReadOnlyCollection<IPathfindingVertex> Neighbors => neighbors;
+
+    public void ConnectTo(TestPathfindingVertex vertex)
+    {
+        if (!neighbors.Contains(vertex))
+        {
+            neighbors.Add(vertex);
+        }
+    }
+
+    public void ConnectBidirectional(TestPathfindingVertex vertex)
+    {
+        ConnectTo(vertex);
+        vertex.ConnectTo(this);
+    }
+
+    public override string ToString()
+    {
+        return $"Vertex[{Position}]";
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/ChebyshevDistanceTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/ChebyshevDistanceTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Heuristics;
+
+[Category("Unit")]
+public class ChebyshevDistanceTests
+{
+    [Test]
+    public void Calculate_ReturnsMaximumAxisDifference()
+    {
+        var first = new TestPathfindingVertex(new Coordinate(0, 0));
+        var second = new TestPathfindingVertex(new Coordinate(3, 5));
+
+        var heuristic = new ChebyshevDistance();
+        var value = heuristic.Calculate(first, second);
+
+        Assert.That(value, Is.EqualTo(5));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/DiagonalDistanceTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/DiagonalDistanceTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Heuristics;
+
+[Category("Unit")]
+public class DiagonalDistanceTests
+{
+    [Test]
+    public void Calculate_CombinesDiagonalAndStraightSteps()
+    {
+        var first = new TestPathfindingVertex(new Coordinate(0, 0));
+        var second = new TestPathfindingVertex(new Coordinate(3, 5));
+
+        var heuristic = new DiagonalDistance();
+        var value = heuristic.Calculate(first, second);
+
+        Assert.That(value, Is.EqualTo(6.242640687119285).Within(1e-12));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/EuclideanDistanceTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/EuclideanDistanceTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Heuristics;
+
+[Category("Unit")]
+public class EuclideanDistanceTests
+{
+    [Test]
+    public void Calculate_ReturnsRoundedEuclideanDistance()
+    {
+        var first = new TestPathfindingVertex(new Coordinate(0, 0));
+        var second = new TestPathfindingVertex(new Coordinate(3, 5));
+
+        var heuristic = new EuclideanDistance();
+        var value = heuristic.Calculate(first, second);
+
+        Assert.That(value, Is.EqualTo(5.8310));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/ManhattanDistanceTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/ManhattanDistanceTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Heuristics;
+
+[Category("Unit")]
+public class ManhattanDistanceTests
+{
+    [Test]
+    public void Calculate_SumsAbsoluteDifferences()
+    {
+        var first = new TestPathfindingVertex(new Coordinate(0, 0));
+        var second = new TestPathfindingVertex(new Coordinate(3, 5));
+
+        var heuristic = new ManhattanDistance();
+        var value = heuristic.Calculate(first, second);
+
+        Assert.That(value, Is.EqualTo(8));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/WeightedHeuristicTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/Heuristics/WeightedHeuristicTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.Heuristics;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.Heuristics;
+
+[Category("Unit")]
+public class WeightedHeuristicTests
+{
+    [Test]
+    public void Calculate_MultipliesInnerHeuristicByWeight()
+    {
+        var first = new TestPathfindingVertex(new Coordinate(0, 0));
+        var second = new TestPathfindingVertex(new Coordinate(3, 5));
+
+        var heuristic = new WeightedHeuristic(new ManhattanDistance(), 2.5);
+        var value = heuristic.Calculate(first, second);
+
+        Assert.That(value, Is.EqualTo(20));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/IdaStarAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/IdaStarAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class IdaStarAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_ProducesSolutionWithinBound()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new IdaStarAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/LeeAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/LeeAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class LeeAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_PerformsBreadthFirstTraversal()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new LeeAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/RandomAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/RandomAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class RandomAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_UsesRandomQueueSafely()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new RandomAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/SnakeAlgorithmTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/SnakeAlgorithmTests.cs
@@ -1,0 +1,19 @@
+using Pathfinding.Infrastructure.Business.Algorithms;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms;
+
+[Category("Unit")]
+public class SnakeAlgorithmTests
+{
+    [Test]
+    public void FindPath_WithLinearGraph_UsesSourceDistanceHeuristic()
+    {
+        var graph = TestGraphFactory.CreateLinearGraph();
+        var algorithm = new SnakeAlgorithm(graph.Range);
+
+        var path = algorithm.FindPath();
+
+        AlgorithmAssert.PathHasExpectedMetrics(path, graph, expectedLength: 2, expectedCost: 2);
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/StepRules/DefaultStepRuleTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/StepRules/DefaultStepRuleTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.StepRules;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.StepRules;
+
+[Category("Unit")]
+public class DefaultStepRuleTests
+{
+    [Test]
+    public void CalculateStepCost_ReturnsNeighbourCost()
+    {
+        var current = new TestPathfindingVertex(new Coordinate(0, 0), cost: 5);
+        var neighbour = new TestPathfindingVertex(new Coordinate(1, 0), cost: 3);
+
+        var rule = new DefaultStepRule();
+        var cost = rule.CalculateStepCost(neighbour, current);
+
+        Assert.That(cost, Is.EqualTo(3));
+    }
+}

--- a/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/StepRules/LandscapeStepRuleTests.cs
+++ b/tests/Pathfinding.Infrastructure.Business.Tests/Algorithms/StepRules/LandscapeStepRuleTests.cs
@@ -1,0 +1,21 @@
+using Pathfinding.Infrastructure.Business.Algorithms.StepRules;
+using Pathfinding.Infrastructure.Business.Tests.Algorithms.Helpers;
+using Pathfinding.Shared.Primitives;
+
+namespace Pathfinding.Infrastructure.Business.Tests.Algorithms.StepRules;
+
+[Category("Unit")]
+public class LandscapeStepRuleTests
+{
+    [Test]
+    public void CalculateStepCost_ReturnsAbsoluteDifference()
+    {
+        var current = new TestPathfindingVertex(new Coordinate(0, 0), cost: 8);
+        var neighbour = new TestPathfindingVertex(new Coordinate(1, 0), cost: 3);
+
+        var rule = new LandscapeStepRule();
+        var cost = rule.CalculateStepCost(neighbour, current);
+
+        Assert.That(cost, Is.EqualTo(5));
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable test graph helpers for pathfinding algorithm scenarios
- add unit tests that cover pathfinding algorithms, heuristics, step rules, graph path models, and related event/exception types

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc2c5d0688333b657e358c738230d)