### PR TITLE
Align console tests with awaitable messenger messages

### DIFF
--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphFieldViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphFieldViewModelTests.cs
@@ -19,7 +19,7 @@ namespace Pathfinding.App.Console.Tests.ViewModelTests;
 internal sealed class GraphFieldViewModelTests
 {
     [Test]
-    public async Task GraphActivatedMessage_EditableGraph_ShouldEnableCommands()
+    public async Task AwaitGraphActivatedMessage_EditableGraph_ShouldEnableCommands()
     {
         var messenger = new StrongReferenceMessenger();
         var serviceMock = new Mock<IRequestService<GraphVertexModel>>();
@@ -27,12 +27,12 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(1, graph, false),
             default,
             default));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         var canExecute = await viewModel.ChangeVertexPolarityCommand.CanExecute.FirstAsync(value => value);
 
@@ -44,7 +44,7 @@ internal sealed class GraphFieldViewModelTests
     }
 
     [Test]
-    public async Task GraphActivatedMessage_ReadonlyGraph_ShouldDisableCommands()
+    public async Task AwaitGraphActivatedMessage_ReadonlyGraph_ShouldDisableCommands()
     {
         var messenger = new StrongReferenceMessenger();
         var serviceMock = new Mock<IRequestService<GraphVertexModel>>();
@@ -52,12 +52,12 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(1, graph, true),
             default,
             default));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         var canExecute = await viewModel.ChangeVertexPolarityCommand.CanExecute.FirstAsync(value => !value);
 
@@ -83,7 +83,7 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(2, graph, false),
             default,
             default));
@@ -92,7 +92,7 @@ internal sealed class GraphFieldViewModelTests
         messenger.Register<ObstaclesCountChangedMessage>(this, (_, msg) => obstaclesMessage = msg);
         messenger.Register<IsVertexInRangeRequestMessage>(this, (_, request) => request.Reply(false));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         await viewModel.ChangeVertexPolarityCommand.Execute(vertex);
 
@@ -120,7 +120,7 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(3, graph, false),
             default,
             default));
@@ -129,7 +129,7 @@ internal sealed class GraphFieldViewModelTests
         messenger.Register<ObstaclesCountChangedMessage>(this, (_, _) => obstaclesSent = true);
         messenger.Register<IsVertexInRangeRequestMessage>(this, (_, request) => request.Reply(true));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         await viewModel.ChangeVertexPolarityCommand.Execute(vertex);
 
@@ -160,12 +160,12 @@ internal sealed class GraphFieldViewModelTests
         var vertex = CreateVertex();
         vertex.Cost = new VertexCost(9, new InclusiveValueRange<int>(10, 0));
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(4, graph, false),
             default,
             default));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         await viewModel.IncreaseVertexCostCommand.Execute(vertex);
 
@@ -197,7 +197,7 @@ internal sealed class GraphFieldViewModelTests
         var vertex = CreateVertex();
         vertex.IsObstacle = true;
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(5, graph, false),
             default,
             default));
@@ -206,7 +206,7 @@ internal sealed class GraphFieldViewModelTests
         messenger.Register<ObstaclesCountChangedMessage>(this, (_, msg) => obstaclesMessage = msg);
         messenger.Register<IsVertexInRangeRequestMessage>(this, (_, request) => request.Reply(false));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         await viewModel.InverseVertexCommand.Execute(vertex);
 
@@ -228,12 +228,12 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(6, graph, false),
             default,
             default));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         var enabled = await viewModel.ChangeVertexPolarityCommand.CanExecute.FirstAsync(value => value);
 
@@ -257,12 +257,12 @@ internal sealed class GraphFieldViewModelTests
 
         var vertex = CreateVertex();
         var graph = new Graph<GraphVertexModel>([vertex], 1);
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(7, graph, false),
             default,
             default));
 
-        messenger.Send(message, Tokens.GraphField);
+        await messenger.Send(message);
 
         var enabled = await viewModel.ChangeVertexPolarityCommand.CanExecute.FirstAsync(value => value);
         Assert.That(enabled, Is.True);

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphTableViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphTableViewModelTests.cs
@@ -103,22 +103,8 @@ internal sealed class GraphTableViewModelTests
             .Setup(x => x.CreateNeighborhoodLayer(It.IsAny<Neighborhoods>()))
             .Returns(new MooreNeighborhoodLayer());
 
-        var runsTableMessages = new List<AwaitGraphActivatedMessage>();
-        messenger.Register<AwaitGraphActivatedMessage, int>(this, Tokens.RunsTable, (_, msg) =>
-        {
-            runsTableMessages.Add(msg);
-            msg.SetCompleted();
-        });
-        var pathfindingMessages = new List<AwaitGraphActivatedMessage>();
-        messenger.Register<AwaitGraphActivatedMessage, int>(this, Tokens.PathfindingRange, (_, msg) =>
-        {
-            pathfindingMessages.Add(msg);
-            msg.SetCompleted();
-        });
-        var fieldMessages = new List<GraphActivatedMessage>();
-        messenger.Register<GraphActivatedMessage, int>(this, Tokens.GraphField, (_, msg) => fieldMessages.Add(msg));
-        var broadcastMessages = new List<GraphActivatedMessage>();
-        messenger.Register<GraphActivatedMessage>(this, (_, msg) => broadcastMessages.Add(msg));
+        var activatedMessages = new List<AwaitGraphActivatedMessage>();
+        messenger.Register<AwaitGraphActivatedMessage>(this, (_, msg) => activatedMessages.Add(msg));
 
         using var viewModel = CreateViewModel(
             messenger,
@@ -134,10 +120,7 @@ internal sealed class GraphTableViewModelTests
                 .Verify(x => x.ReadGraphAsync(
                     It.Is<int>(z => z == 1),
                     It.IsAny<CancellationToken>()), Times.Once);
-            Assert.That(fieldMessages, Has.Count.EqualTo(1));
-            Assert.That(runsTableMessages, Has.Count.EqualTo(1));
-            Assert.That(pathfindingMessages, Has.Count.EqualTo(1));
-            Assert.That(broadcastMessages, Has.Count.EqualTo(1));
+            Assert.That(activatedMessages, Has.Count.EqualTo(1));
         });
     }
 

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/GraphUpdateViewModelTests.cs
@@ -93,22 +93,8 @@ internal sealed class GraphUpdateViewModelTests
                 It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(true));
 
-        var graphTableMessages = new List<AwaitGraphUpdatedMessage>();
-        messenger.Register<AwaitGraphUpdatedMessage, int>(this, Tokens.GraphTable, (_, msg) =>
-        {
-            graphTableMessages.Add(msg);
-            msg.SetCompleted();
-        });
-
-        var algorithmUpdateMessages = new List<AwaitGraphUpdatedMessage>();
-        messenger.Register<AwaitGraphUpdatedMessage, int>(this, Tokens.AlgorithmUpdate, (_, msg) =>
-        {
-            algorithmUpdateMessages.Add(msg);
-            msg.SetCompleted();
-        });
-
-        GraphUpdatedMessage broadcastMessage = null;
-        messenger.Register<GraphUpdatedMessage>(this, (_, msg) => broadcastMessage = msg);
+        var updatedMessages = new List<AwaitGraphUpdatedMessage>();
+        messenger.Register<AwaitGraphUpdatedMessage>(this, (_, msg) => updatedMessages.Add(msg));
 
         using var viewModel = CreateViewModel(messenger, serviceMock, neighborhoodFactoryMock);
 
@@ -129,9 +115,7 @@ internal sealed class GraphUpdateViewModelTests
                        && model.Name == newName
                        && model.Neighborhood == Neighborhoods.Moore),
                 It.IsAny<CancellationToken>()), Times.Once);
-            Assert.That(graphTableMessages, Has.Count.EqualTo(1));
-            Assert.That(algorithmUpdateMessages, Has.Count.EqualTo(1));
-            Assert.That(broadcastMessage, Is.Not.Null);
+            Assert.That(updatedMessages, Has.Count.EqualTo(1));
         });
     }
 

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunCreateViewModelTests.cs
@@ -39,11 +39,11 @@ internal sealed class RunCreateViewModelTests
             stepRuleFactoryMock);
 
         var graph = CreateGraph();
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(42, graph, false),
             default,
             default));
-        messenger.Send(message);
+        await messenger.Send(message);
 
         viewModel.SelectedAlgorithms.Add(Algorithms.AStar);
 
@@ -86,11 +86,11 @@ internal sealed class RunCreateViewModelTests
             logMock.Object);
 
         var graph = CreateGraph();
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(42, graph, false),
             default,
             default));
-        messenger.Send(message);
+        await messenger.Send(message);
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
             => msg.Reply([.. graph.Select(v => v)]));
@@ -133,7 +133,7 @@ internal sealed class RunCreateViewModelTests
 
         var graph = CreateGraph();
 
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(42, graph, false),
             default,
             default));

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunFieldViewModelTests.cs
@@ -15,7 +15,7 @@ namespace Pathfinding.App.Console.Tests.ViewModelTests;
 internal sealed class RunFieldViewModelTests
 {
     [Test]
-    public void GraphActivatedMessage_ShouldAssembleRunGraph()
+    public async Task AwaitGraphActivatedMessage_ShouldAssembleRunGraph()
     {
         var messenger = new StrongReferenceMessenger();
         var graphAssemble = new GraphAssemble<RunVertexModel>();
@@ -27,17 +27,17 @@ internal sealed class RunFieldViewModelTests
             messenger);
 
         var graph = CreateGraph();
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(1, graph, false),
             default,
             default));
-        messenger.Send(message);
+        await messenger.Send(message);
 
         Assert.That(viewModel.RunGraph, Is.Not.EqualTo(Graph<RunVertexModel>.Empty));
     }
 
     [Test]
-    public void RunsSelectedMessage_ShouldActivateRun()
+    public async Task RunsSelectedMessage_ShouldActivateRun()
     {
         var messenger = new StrongReferenceMessenger();
         var graphAssemble = new GraphAssemble<RunVertexModel>();
@@ -49,11 +49,11 @@ internal sealed class RunFieldViewModelTests
             messenger);
 
         var graph = CreateGraph();
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(42, graph, false),
             default,
             default));
-        messenger.Send(message);
+        await messenger.Send(message);
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
             => msg.Reply([.. graph]));
@@ -65,7 +65,7 @@ internal sealed class RunFieldViewModelTests
     }
 
     [Test]
-    public void RunsDeletedMessage_ShouldClearSelectedRun()
+    public async Task RunsDeletedMessage_ShouldClearSelectedRun()
     {
         var messenger = new StrongReferenceMessenger();
         var graphAssemble = new GraphAssemble<RunVertexModel>();
@@ -77,11 +77,11 @@ internal sealed class RunFieldViewModelTests
             messenger);
 
         var graph = CreateGraph();
-        var message = new GraphActivatedMessage(new ActivatedGraphModel(
+        var message = new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(42, graph, false),
             default,
             default));
-        messenger.Send(message);
+        await messenger.Send(message);
 
         messenger.Register<PathfindingRangeRequestMessage>(this, (_, msg)
             => msg.Reply([.. graph]));

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunRangeViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunRangeViewModelTests.cs
@@ -158,7 +158,7 @@ internal sealed class RunRangeViewModelTests
             new(graphId, graph, status == GraphStatuses.Readonly),
             default,
             default));
-        await messenger.Send(message, Tokens.PathfindingRange);
+        await messenger.Send(message);
     }
 
     private static RunRangeViewModel CreateViewModel(

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunTableViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunTableViewModelTests.cs
@@ -67,7 +67,7 @@ internal sealed class RunTableViewModelTests
 
         using var viewModel = CreateViewModel(messenger, statisticsMock, graphInfoMock);
 
-        await messenger.Send(CreateActivatedMessage(1), Tokens.RunsTable);
+        await messenger.Send(CreateActivatedMessage(1));
 
         Assert.Multiple(() =>
         {
@@ -111,7 +111,7 @@ internal sealed class RunTableViewModelTests
 
         using var viewModel = CreateViewModel(messenger, statisticsMock, graphInfoMock);
 
-        await messenger.Send(CreateActivatedMessage(1), Tokens.RunsTable);
+        await messenger.Send(CreateActivatedMessage(1));
 
         messenger.Send(new GraphsDeletedMessage([1]));
 
@@ -154,7 +154,7 @@ internal sealed class RunTableViewModelTests
 
         using var viewModel = CreateViewModel(messenger, statisticsMock, graphInfoMock);
 
-        await messenger.Send(CreateActivatedMessage(1), Tokens.RunsTable);
+        await messenger.Send(CreateActivatedMessage(1));
 
         var stateChanged = new TaskCompletionSource();
         messenger.Register<GraphStateChangedMessage>(this, (_, msg) =>
@@ -195,7 +195,7 @@ internal sealed class RunTableViewModelTests
 
         using var viewModel = CreateViewModel(messenger, statisticsMock, graphInfoMock, logMock.Object);
 
-        await messenger.Send(CreateActivatedMessage(1), Tokens.RunsTable);
+        await messenger.Send(CreateActivatedMessage(1));
 
         logMock
             .Verify(x => x.Error(

--- a/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
+++ b/tests/Pathfinding.App.Console.Tests/ViewModelTests/RunUpdateViewModelTests.cs
@@ -38,7 +38,7 @@ internal sealed class RunUpdateViewModelTests
 
         var graph = CreateGraph();
 
-        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+        await messenger.Send(new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(10, graph, false),
             Neighborhoods.Moore,
             SmoothLevels.No)));
@@ -95,7 +95,7 @@ internal sealed class RunUpdateViewModelTests
             algorithmsFactoryMock,
             neighborhoodFactoryMock);
 
-        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+        await messenger.Send(new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(10, graph, false),
             default,
             default)));
@@ -139,7 +139,7 @@ internal sealed class RunUpdateViewModelTests
             neighborhoodFactoryMock);
 
         var graph = CreateGraph();
-        messenger.Send(new GraphActivatedMessage(new ActivatedGraphModel(
+        await messenger.Send(new AwaitGraphActivatedMessage(new ActivatedGraphModel(
             new(5, graph, false),
             default,
             default)));


### PR DESCRIPTION
## Summary
- update console view model tests to use the new awaitable graph activation and update messages
- remove obsolete token-based registrations and synchronous graph activation expectations
- ensure tests await messenger interactions that now rely on IAwaitableMessage

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0ba512f48333a08d007fa8e85b56)